### PR TITLE
Creative mode tab improvements

### DIFF
--- a/common/src/main/java/concerrox/emixx/mixin/EmiReloadManagerReloadWorkerMixin.java
+++ b/common/src/main/java/concerrox/emixx/mixin/EmiReloadManagerReloadWorkerMixin.java
@@ -1,6 +1,7 @@
 package concerrox.emixx.mixin;
 
 import concerrox.emixx.content.StackManager;
+import concerrox.emixx.content.creativemodetab.CreativeModeTabManager;
 import concerrox.emixx.content.stackgroup.StackGroupManager;
 import dev.emi.emi.runtime.EmiLog;
 import dev.emi.emi.runtime.EmiReloadManager;
@@ -27,6 +28,7 @@ public class EmiReloadManagerReloadWorkerMixin {
 
         StackGroupManager.INSTANCE.reload$emixx_common();
         StackManager.INSTANCE.reload$emixx_common();
+        CreativeModeTabManager.INSTANCE.reload$emixx_common();
     }
 
 }

--- a/common/src/main/kotlin/concerrox/emixx/config/ConfigScreenManager.kt
+++ b/common/src/main/kotlin/concerrox/emixx/config/ConfigScreenManager.kt
@@ -3,6 +3,7 @@ package concerrox.emixx.config
 import com.electronwill.nightconfig.core.AbstractConfig
 import concerrox.emixx.EmiPlusPlus
 import concerrox.emixx.Minecraft
+import concerrox.emixx.content.creativemodetab.gui.CreativeModeTabConfigScreen
 import concerrox.emixx.content.stackgroup.gui.StackGroupConfigScreen
 import concerrox.emixx.text
 import dev.emi.emi.EmiPort
@@ -58,7 +59,11 @@ object ConfigScreenManager {
                     )
 
                     else -> ActionWidget(itemTitle, itemTooltip, searcher) {
-                        Minecraft.setScreen(StackGroupConfigScreen())
+                        Minecraft.setScreen(when (itemValue) {
+                            EmiPlusPlusConfig.disabledCreativeModeTabs -> CreativeModeTabConfigScreen()
+                            EmiPlusPlusConfig.disabledStackGroups -> StackGroupConfigScreen()
+                            else -> error("[EMI++] Undefined config screen for $itemKey!")
+                        })
                     }
                 }?.apply {
                     this.group = EmiConfig.ConfigGroup(groupKey)

--- a/common/src/main/kotlin/concerrox/emixx/config/EmiPlusPlusConfig.kt
+++ b/common/src/main/kotlin/concerrox/emixx/config/EmiPlusPlusConfig.kt
@@ -23,6 +23,7 @@ class EmiPlusPlusConfig(builder: ModConfigSpec.Builder) {
 
         lateinit var enableCreativeModeTabs: ModConfigSpec.BooleanValue
         lateinit var syncSelectedCreativeModeTab: ModConfigSpec.BooleanValue
+        lateinit var disabledCreativeModeTabs: ModConfigSpec.ConfigValue<List<String>>
         lateinit var enableStackGroups: ModConfigSpec.BooleanValue
         lateinit var disabledStackGroups: ModConfigSpec.ConfigValue<List<String>>
     }
@@ -31,6 +32,11 @@ class EmiPlusPlusConfig(builder: ModConfigSpec.Builder) {
         builder.group("creativeModeTabs") {
             enableCreativeModeTabs = define("enableCreativeModeTabs", true)
             syncSelectedCreativeModeTab = define("syncSelectedCreativeModeTab", true)
+            disabledCreativeModeTabs = defineListAllowEmpty("disabledCreativeModeTabs", {
+                listOf(
+                    "minecraft:op_blocks"
+                )
+            }, { "" }, { it is String })
         }
         builder.group("stackGroups") {
             enableStackGroups = define("enableStackGroups", true)

--- a/common/src/main/kotlin/concerrox/emixx/content/creativemodetab/CreativeModeTabManager.kt
+++ b/common/src/main/kotlin/concerrox/emixx/content/creativemodetab/CreativeModeTabManager.kt
@@ -23,7 +23,7 @@ object CreativeModeTabManager {
 
     private var currentTabPage = 0u
     private var lastTabPage = 0u
-    private var currentTab = 0u
+    private var currentTab: UInt? = null
 
     private var isSelectingVanillaCreativeInventoryTabByEmiPlusPlus = false
     private var isSelectingEmiPlusPlusCreativeModeTabByVanilla = false
@@ -50,8 +50,10 @@ object CreativeModeTabManager {
 
         // TODO: fix the sound
         // Select the index tab by default
-        CreativeModeTabGui.selectTab(0, false)
-        onTabSelected(CreativeModeTabGui.tabNavigationBar.tabs[0] as ItemTab)
+        if (currentTab == null) {
+            CreativeModeTabGui.selectTab(0, false)
+            onTabSelected(CreativeModeTabGui.tabNavigationBar.tabs[0] as ItemTab)
+        }
     }
 
     internal fun reload() {
@@ -83,7 +85,9 @@ object CreativeModeTabManager {
             return
         }
         // TODO: refactor this
-        currentTab = CreativeModeTabGui.tabNavigationBar.tabs.indexOf(tab).toUInt()
+        val newTab = CreativeModeTabGui.tabNavigationBar.tabs.indexOf(tab).toUInt()
+        if (currentTab == newTab) return
+        currentTab = newTab
 
         CreativeModeTabGui.tabNavigationBar.tabButtons.forEachIndexed { i, it ->
             if (i.toUInt() != currentTab) it.isFocused = false

--- a/common/src/main/kotlin/concerrox/emixx/content/creativemodetab/gui/CreativeModeTabConfigScreen.kt
+++ b/common/src/main/kotlin/concerrox/emixx/content/creativemodetab/gui/CreativeModeTabConfigScreen.kt
@@ -1,0 +1,25 @@
+package concerrox.emixx.content.creativemodetab.gui
+
+import concerrox.emixx.config.EmiPlusPlusConfig
+import concerrox.emixx.content.creativemodetab.CreativeModeTabManager
+import concerrox.emixx.gui.GridList
+import concerrox.emixx.gui.GridListConfigScreen
+import net.minecraft.resources.ResourceLocation
+
+class CreativeModeTabConfigScreen : GridListConfigScreen("creative_mode_tab_config") {
+
+    private val disabledCreativeModeTabs =
+        EmiPlusPlusConfig.disabledCreativeModeTabs.get().map { ResourceLocation.parse(it) }.toMutableSet()
+
+    override fun createList(): GridList<*> = CreativeModeTabGridList(this, disabledCreativeModeTabs)
+
+    override fun save() {
+        EmiPlusPlusConfig.disabledCreativeModeTabs.set(disabledCreativeModeTabs.map { it.toString() }.toList())
+        EmiPlusPlusConfig.save()
+    }
+
+    override fun reload() {
+        CreativeModeTabManager.reload()
+    }
+
+}

--- a/common/src/main/kotlin/concerrox/emixx/content/creativemodetab/gui/CreativeModeTabGridList.kt
+++ b/common/src/main/kotlin/concerrox/emixx/content/creativemodetab/gui/CreativeModeTabGridList.kt
@@ -1,0 +1,73 @@
+package concerrox.emixx.content.creativemodetab.gui
+
+import concerrox.emixx.content.ScreenManager.ENTRY_SIZE
+import concerrox.emixx.content.creativemodetab.CreativeModeTabManager
+import concerrox.emixx.gui.GridList
+import concerrox.emixx.gui.ListEntry
+import concerrox.emixx.gui.components.Switch
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.components.AbstractWidget
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.network.chat.Component
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.item.CreativeModeTab
+
+class CreativeModeTabGridList(
+    screen: CreativeModeTabConfigScreen, private val disabledCreativeModeTabs: MutableSet<ResourceLocation>
+) : GridList<ResourceLocation>(screen) {
+
+    override fun getContents(): Collection<ResourceLocation> =
+        BuiltInRegistries.CREATIVE_MODE_TAB.keySet().filter {
+            val tab = BuiltInRegistries.CREATIVE_MODE_TAB.get(it) ?: return@filter false
+            return@filter tab.shouldDisplay() && tab !in CreativeModeTabManager.HIDDEN_CREATIVE_MODE_TABS
+        }
+
+    override fun getEntryForContent(
+        content: ResourceLocation?,
+        triple: TripleEntry<ResourceLocation>
+    ): ListEntry {
+        return StackGroupEntry(content, triple, disabledCreativeModeTabs, BuiltInRegistries.CREATIVE_MODE_TAB.get(content))
+    }
+
+    class StackGroupEntry(
+        private val id: ResourceLocation?,
+        triple: TripleEntry<ResourceLocation>,
+        private val disabledCreativeModeTabs: MutableSet<ResourceLocation>,
+        private val tab: CreativeModeTab?
+    ): ListEntry(triple) {
+
+        override val switch = Switch.Builder(Component.empty())
+            .setChecked(id != null && !disabledCreativeModeTabs.contains(id)).apply {
+                onCheckedChangeListener = Switch.OnCheckedChangeListener { _, isChecked ->
+                    if (id != null) {
+                        if (isChecked) {
+                            disabledCreativeModeTabs.remove(id)
+                        } else {
+                            disabledCreativeModeTabs.add(id)
+                        }
+                    }
+                }
+            }.build()
+        override val children = mutableListOf<AbstractWidget>(switch)
+
+        override fun shouldRenderSwitch(): Boolean = tab != null && id != null
+
+        override fun getEntryTitle(): Component? = tab?.displayName
+
+        override fun renderEntry(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, startX: Int, startY: Int, partialTick: Float) {
+            tab?.let {
+                var itemX = startX
+                val itemY = startY + ENTRY_SIZE
+                val font = Minecraft.getInstance().font
+                tab.displayItems.take(8).forEach {
+                    guiGraphics.renderItem(it, itemX, itemY)
+                    guiGraphics.renderItemDecorations(font, it, itemX, itemY, "")
+                    itemX += ENTRY_SIZE
+                }
+            }
+        }
+
+    }
+
+}

--- a/common/src/main/kotlin/concerrox/emixx/content/creativemodetab/gui/CreativeModeTabGui.kt
+++ b/common/src/main/kotlin/concerrox/emixx/content/creativemodetab/gui/CreativeModeTabGui.kt
@@ -9,8 +9,6 @@ import concerrox.emixx.gui.components.ImageButton
 import concerrox.emixx.util.pos
 import dev.emi.emi.config.EmiConfig
 import dev.emi.emi.config.HeaderType
-import dev.emi.emi.registry.EmiExclusionAreas
-import dev.emi.emi.screen.EmiScreenBase
 import net.minecraft.client.gui.screens.Screen
 
 object CreativeModeTabGui {
@@ -30,8 +28,8 @@ object CreativeModeTabGui {
     internal val tabNavigationBar = ItemTabNavigationBar(tabManager).pos(0, 0)
     internal var tabCount = 0u
 
-    private val buttonPrevious = ImageButton(16, 16, u = 0, v = 0, { true }, CreativeModeTabManager::previousPage).pos(0, 0)
-    private val buttonNext = ImageButton(16, 16, u = 16, v = 0, { true }, CreativeModeTabManager::nextPage).pos(0, 0)
+    private val buttonPrevious = ImageButton(16, 16, u = 0, v = 0, { true }, CreativeModeTabManager::previousPage).matchScreenManagerVisibility().pos(0, 0)
+    private val buttonNext = ImageButton(16, 16, u = 16, v = 0, { true }, CreativeModeTabManager::nextPage).matchScreenManagerVisibility().pos(0, 0)
 
     private var scrollAccumulator = 0.0
 

--- a/common/src/main/kotlin/concerrox/emixx/content/creativemodetab/gui/itemtab/ItemTabNavigationBar.kt
+++ b/common/src/main/kotlin/concerrox/emixx/content/creativemodetab/gui/itemtab/ItemTabNavigationBar.kt
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.systems.RenderSystem
 import concerrox.emixx.content.ScreenManager.ENTRY_SIZE
 import concerrox.emixx.res
 import dev.emi.emi.runtime.EmiDrawContext
+import dev.emi.emi.screen.EmiScreenManager
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.components.TabButton
 import net.minecraft.client.gui.components.events.GuiEventListener
@@ -38,6 +39,8 @@ class ItemTabNavigationBar(private val tabManager: ItemTabManager) : TabNavigati
     }
 
     override fun render(raw: GuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
+        if (EmiScreenManager.isDisabled()) return
+
         RenderSystem.enableBlend()
         EmiDrawContext.wrap(raw).apply {
             drawTexture(TEXTURE, x, y + 2, 32, 0, 1, 16)

--- a/common/src/main/kotlin/concerrox/emixx/content/stackgroup/gui/StackGroupConfigScreen.kt
+++ b/common/src/main/kotlin/concerrox/emixx/content/stackgroup/gui/StackGroupConfigScreen.kt
@@ -3,58 +3,25 @@ package concerrox.emixx.content.stackgroup.gui
 import concerrox.emixx.config.EmiPlusPlusConfig
 import concerrox.emixx.content.StackManager
 import concerrox.emixx.content.stackgroup.StackGroupManager
-import concerrox.emixx.text
-import net.fabricmc.api.EnvType
-import net.fabricmc.api.Environment
-import net.minecraft.client.gui.components.Button
-import net.minecraft.client.gui.components.tabs.GridLayoutTab
-import net.minecraft.client.gui.components.tabs.TabManager
-import net.minecraft.client.gui.components.tabs.TabNavigationBar
-import net.minecraft.client.gui.layouts.HeaderAndFooterLayout
-import net.minecraft.client.gui.navigation.ScreenRectangle
-import net.minecraft.client.gui.screens.Screen
-import net.minecraft.network.chat.CommonComponents
+import concerrox.emixx.gui.GridList
+import concerrox.emixx.gui.GridListConfigScreen
 import net.minecraft.resources.ResourceLocation
 
-class StackGroupConfigScreen : Screen(text("gui", "stack_group_config")) {
+class StackGroupConfigScreen : GridListConfigScreen("stack_group_config") {
 
     private val disabledStackGroups =
         EmiPlusPlusConfig.disabledStackGroups.get().map { ResourceLocation.parse(it) }.toMutableSet()
 
-    private val layout = HeaderAndFooterLayout(this)
-    private val list = StackGroupGridList(this, disabledStackGroups)
-    private val tabManager = TabManager(::addRenderableWidget, ::removeWidget)
-    private val tabNavigationBar = TabNavigationBar.builder(tabManager, width).addTabs(
-        PrebuiltTab()
-    ).build()
+    override fun createList(): GridList<*> = StackGroupGridList(this, disabledStackGroups)
 
-    override fun init() {
-        layout.addTitleHeader(title, font)
-        layout.addToContents(list)
-        layout.addToFooter(Button.builder(CommonComponents.GUI_DONE) {
-            EmiPlusPlusConfig.disabledStackGroups.set(disabledStackGroups.map { it.toString() }.toList())
-            EmiPlusPlusConfig.save()
-            onClose()
-
-            StackGroupManager.reload()
-            StackManager.reload()
-        }.width(200).build())
-        layout.visitWidgets(::addRenderableWidget)
-        repositionElements()
-        list.add()
+    override fun save() {
+        EmiPlusPlusConfig.disabledStackGroups.set(disabledStackGroups.map { it.toString() }.toList())
+        EmiPlusPlusConfig.save()
     }
 
-    override fun repositionElements() {
-        list.updateSize(width, layout)
-        //        list.width = width
-//        list.height = layout.contentHeight
-        layout.arrangeElements()
-        tabNavigationBar.setWidth(width)
-        tabNavigationBar.arrangeElements()
-        tabManager.setTabArea(ScreenRectangle(0, tabNavigationBar.rectangle.bottom(), width, height))
+    override fun reload() {
+        StackGroupManager.reload()
+        StackManager.reload()
     }
-
-    @Environment(EnvType.CLIENT)
-    private class PrebuiltTab : GridLayoutTab(text("gui", "stack_group_config.prebuilt"))
 
 }

--- a/common/src/main/kotlin/concerrox/emixx/content/stackgroup/gui/StackGroupGridList.kt
+++ b/common/src/main/kotlin/concerrox/emixx/content/stackgroup/gui/StackGroupGridList.kt
@@ -1,84 +1,57 @@
 package concerrox.emixx.content.stackgroup.gui
 
-import com.mojang.blaze3d.systems.RenderSystem
 import concerrox.emixx.content.ScreenManager.ENTRY_SIZE
 import concerrox.emixx.content.stackgroup.EmiGroupStack
 import concerrox.emixx.content.stackgroup.StackGroupManager
+import concerrox.emixx.gui.GridList
+import concerrox.emixx.gui.ListEntry
 import concerrox.emixx.gui.components.Switch
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiGraphics
-import net.minecraft.client.gui.components.AbstractContainerWidget
-import net.minecraft.client.gui.components.ContainerObjectSelectionList
-import net.minecraft.client.gui.narration.NarrationElementOutput
-import net.minecraft.client.gui.screens.Screen
+import net.minecraft.client.gui.components.AbstractWidget
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 
 class StackGroupGridList(
-    private val screen: StackGroupConfigScreen, private val disabledStackGroups: MutableSet<ResourceLocation>
-) : ContainerObjectSelectionList<StackGroupGridList.TripleEntry>(
-    Minecraft.getInstance(), screen.width, screen.height, 0, TripleEntry.HEIGHT
-) {
+    screen: StackGroupConfigScreen, private val disabledStackGroups: MutableSet<ResourceLocation>
+) : GridList<EmiGroupStack>(screen) {
 
-    init {
-        centerListVertically = false
-        setRenderHeader(true, 16)
+    override fun getContents(): Collection<EmiGroupStack> =
+        StackGroupManager.stackGroupToGroupStacks.values
+
+    override fun getEntryForContent(
+        content: EmiGroupStack?,
+        triple: TripleEntry<EmiGroupStack>
+    ): ListEntry {
+        return StackGroupEntry(content, triple, disabledStackGroups)
     }
 
-    override fun getRowWidth() = TripleEntry.WIDTH
-    //override fun getListOutlinePadding() = TripleEntry.GUTTER
+    class StackGroupEntry(
+        private val stack: EmiGroupStack?,
+        triple: TripleEntry<EmiGroupStack>,
+        private val disabledStackGroups: MutableSet<ResourceLocation>
+    ): ListEntry(triple) {
 
-    fun add() {
-        StackGroupManager.stackGroupToGroupStacks.values.chunked(3).forEach { triple ->
-            addEntry(TripleEntry(this, triple))
-        }
-    }
-
-//    override fun getRowTop(index: Int): Int {
-//        return y + TripleEntry.GUTTER * 2 - scrollAmount.toInt() + index * itemHeight + headerHeight
-//    }
-
-    class StackGroupEntry(private val triple: TripleEntry, private val stack: EmiGroupStack?) :
-        AbstractContainerWidget(
-            0, 0, WIDTH, HEIGHT, Component.empty()
-        ) {
-
-        companion object {
-            private val BACKGROUND =
-                ResourceLocation.withDefaultNamespace("textures/gui/inworld_menu_list_background.png")
-            private const val PADDING = 8
-            private const val BORDER_WIDTH = 1
-            const val WIDTH = ENTRY_SIZE * 8 + PADDING * 2 + BORDER_WIDTH * 2
-            const val HEIGHT = ENTRY_SIZE * 2 + PADDING * 2 + BORDER_WIDTH * 2
-        }
-
-        private val switch = Switch.Builder(Component.empty())
-            .setChecked(stack != null && !triple.listWidget.disabledStackGroups.contains(stack.group.id)).apply {
+        override val switch = Switch.Builder(Component.empty())
+            .setChecked(stack != null && !disabledStackGroups.contains(stack.group.id)).apply {
                 onCheckedChangeListener = Switch.OnCheckedChangeListener { _, isChecked ->
                     if (stack != null) {
                         if (isChecked) {
-                            triple.listWidget.disabledStackGroups.remove(stack.group.id)
+                            disabledStackGroups.remove(stack.group.id)
                         } else {
-                            triple.listWidget.disabledStackGroups.add(stack.group.id)
+                            disabledStackGroups.add(stack.group.id)
                         }
                     }
                 }
             }.build()
-        private val children = mutableListOf(switch)
+        override val children = mutableListOf<AbstractWidget>(switch)
 
-        override fun renderWidget(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
-            renderBackground(guiGraphics)
-            renderBorders(guiGraphics)
-            val startX = x + BORDER_WIDTH + PADDING
-            val startY = y + BORDER_WIDTH + PADDING
+        override fun shouldRenderSwitch(): Boolean = stack != null
+
+        override fun getEntryTitle(): Component? =
+            if (stack != null) Component.literal(stack.group.id.toString()) else null
+
+        override fun renderEntry(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, startX: Int, startY: Int, partialTick: Float) {
             stack?.let {
-                guiGraphics.drawString(
-                    Minecraft.getInstance().font,
-                    stack.group.id.toString(),
-                    startX,
-                    startY + 2,
-                    0xFFFFFF
-                )
                 var itemX = startX
                 val itemY = startY + ENTRY_SIZE
                 stack.items.take(8).forEach {
@@ -86,78 +59,8 @@ class StackGroupGridList(
                     itemX += ENTRY_SIZE
                 }
             }
-            if (stack != null) {
-                switch.setPosition(x + WIDTH - switch.width - BORDER_WIDTH - PADDING, startY)
-                switch.render(guiGraphics, mouseX, mouseY, partialTick)
-            }
         }
-
-        override fun setFocused(isFocused: Boolean) {
-            if (!isFocused) children.forEach {
-                it.isFocused = false
-            }
-        }
-
-        private fun renderBorders(guiGraphics: GuiGraphics) {
-            RenderSystem.enableBlend()
-            val resourceLocation = Screen.INWORLD_HEADER_SEPARATOR
-            val resourceLocation2 = Screen.INWORLD_FOOTER_SEPARATOR
-            guiGraphics.blit(resourceLocation, x, y, 0f, 0f, getWidth(), 2, 32, 2)
-            guiGraphics.blit(resourceLocation2, x, bottom, 0f, 0f, getWidth(), 2, 32, 2)
-            RenderSystem.disableBlend()
-        }
-
-        private fun renderBackground(guiGraphics: GuiGraphics) {
-            RenderSystem.enableBlend()
-            guiGraphics.blit(BACKGROUND, x, y, right.toFloat(), bottom.toFloat(), getWidth(), getHeight(), 32, 32)
-            RenderSystem.disableBlend()
-        }
-
-        override fun isFocused() = triple.focused === this
-        override fun updateWidgetNarration(narrationElementOutput: NarrationElementOutput) {}
-        override fun children() = children
 
     }
 
-    class TripleEntry(val listWidget: StackGroupGridList, stack: List<EmiGroupStack?>) : Entry<TripleEntry>() {
-
-        companion object {
-            const val GUTTER = 6
-            const val WIDTH = StackGroupEntry.WIDTH * 3 + GUTTER * 2
-            const val HEIGHT = StackGroupEntry.HEIGHT + GUTTER * 2
-        }
-
-        private val children = mutableListOf<StackGroupEntry>().apply {
-            for (i in 0..2) {
-                val stack = stack.getOrNull(i)?.let {
-                    add(StackGroupEntry(this@TripleEntry, it))
-                }
-
-            }
-        }
-
-        override fun render(
-            guiGraphics: GuiGraphics,
-            index: Int,
-            top: Int,
-            left: Int,
-            width: Int,
-            height: Int,
-            mouseX: Int,
-            mouseY: Int,
-            isHovered: Boolean,
-            partialTick: Float
-        ) {
-            var xOffset = 0
-            val startX = (listWidget.screen.width - WIDTH) / 2
-            for (abstractWidget in children) {
-                abstractWidget.setPosition(startX + xOffset, top)
-                abstractWidget.render(guiGraphics, mouseX, mouseY, partialTick)
-                xOffset += StackGroupEntry.WIDTH + GUTTER * 2
-            }
-        }
-
-        override fun children() = children
-        override fun narratables() = children
-    }
 }

--- a/common/src/main/kotlin/concerrox/emixx/gui/GridList.kt
+++ b/common/src/main/kotlin/concerrox/emixx/gui/GridList.kt
@@ -1,0 +1,79 @@
+package concerrox.emixx.gui
+
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.components.ContainerObjectSelectionList
+import net.minecraft.client.gui.screens.Screen
+
+abstract class GridList<Contents>(
+    private val screen: Screen
+) : ContainerObjectSelectionList<GridList.TripleEntry<Contents>>(
+    Minecraft.getInstance(), screen.width, screen.height, 0, TripleEntry.HEIGHT
+) {
+
+    init {
+        centerListVertically = false
+        setRenderHeader(true, 16)
+    }
+
+    override fun getRowWidth() = TripleEntry.WIDTH
+    //override fun getListOutlinePadding() = TripleEntry.GUTTER
+
+    abstract fun getContents(): Collection<Contents>
+
+    abstract fun getEntryForContent(content: Contents?, triple: TripleEntry<Contents>): ListEntry
+
+    fun add() {
+        getContents().chunked(3).forEach { triple ->
+            addEntry(TripleEntry(this, triple))
+        }
+    }
+
+//    override fun getRowTop(index: Int): Int {
+//        return y + TripleEntry.GUTTER * 2 - scrollAmount.toInt() + index * itemHeight + headerHeight
+//    }
+
+    class TripleEntry<Contents>(
+        val listWidget: GridList<Contents>,
+        contentsList: List<Contents>
+    ) : Entry<TripleEntry<Contents>>() {
+
+        companion object {
+            const val GUTTER = 6
+            const val WIDTH = ListEntry.WIDTH * 3 + GUTTER * 2
+            const val HEIGHT = ListEntry.HEIGHT + GUTTER * 2
+        }
+
+        private val children = mutableListOf<ListEntry>().apply {
+            for (i in 0..2) {
+                contentsList.getOrNull(i)?.let {
+                    add(listWidget.getEntryForContent(it, this@TripleEntry))
+                }
+            }
+        }
+
+        override fun render(
+            guiGraphics: GuiGraphics,
+            index: Int,
+            top: Int,
+            left: Int,
+            width: Int,
+            height: Int,
+            mouseX: Int,
+            mouseY: Int,
+            isHovered: Boolean,
+            partialTick: Float
+        ) {
+            var xOffset = 0
+            val startX = (listWidget.screen.width - WIDTH) / 2
+            for (abstractWidget in children) {
+                abstractWidget.setPosition(startX + xOffset, top)
+                abstractWidget.render(guiGraphics, mouseX, mouseY, partialTick)
+                xOffset += ListEntry.WIDTH + GUTTER * 2
+            }
+        }
+
+        override fun children() = children
+        override fun narratables() = children
+    }
+}

--- a/common/src/main/kotlin/concerrox/emixx/gui/GridListConfigScreen.kt
+++ b/common/src/main/kotlin/concerrox/emixx/gui/GridListConfigScreen.kt
@@ -1,0 +1,55 @@
+package concerrox.emixx.gui
+
+import concerrox.emixx.text
+import net.fabricmc.api.EnvType
+import net.fabricmc.api.Environment
+import net.minecraft.client.gui.components.Button
+import net.minecraft.client.gui.components.tabs.GridLayoutTab
+import net.minecraft.client.gui.components.tabs.TabManager
+import net.minecraft.client.gui.components.tabs.TabNavigationBar
+import net.minecraft.client.gui.layouts.HeaderAndFooterLayout
+import net.minecraft.client.gui.navigation.ScreenRectangle
+import net.minecraft.client.gui.screens.Screen
+import net.minecraft.network.chat.CommonComponents
+
+abstract class GridListConfigScreen(val name: String) : Screen(text("gui", name)) {
+
+    private val layout = HeaderAndFooterLayout(this)
+    private lateinit var list: GridList<*>
+    private val tabManager = TabManager(::addRenderableWidget, ::removeWidget)
+    private val tabNavigationBar = TabNavigationBar.builder(tabManager, width).addTabs(
+        PrebuiltTab(name)
+    ).build()
+
+    abstract fun createList(): GridList<*>
+    abstract fun save()
+    abstract fun reload()
+
+    override fun init() {
+        list = createList()
+        layout.addTitleHeader(title, font)
+        layout.addToContents(list)
+        layout.addToFooter(Button.builder(CommonComponents.GUI_DONE) {
+            save()
+            onClose()
+            reload()
+        }.width(200).build())
+        layout.visitWidgets(::addRenderableWidget)
+        repositionElements()
+        list.add()
+    }
+
+    override fun repositionElements() {
+        list.updateSize(width, layout)
+        //        list.width = width
+//        list.height = layout.contentHeight
+        layout.arrangeElements()
+        tabNavigationBar.setWidth(width)
+        tabNavigationBar.arrangeElements()
+        tabManager.setTabArea(ScreenRectangle(0, tabNavigationBar.rectangle.bottom(), width, height))
+    }
+
+    @Environment(EnvType.CLIENT)
+    private class PrebuiltTab(name: String) : GridLayoutTab(text("gui", "$name.prebuilt"))
+
+}

--- a/common/src/main/kotlin/concerrox/emixx/gui/ListEntry.kt
+++ b/common/src/main/kotlin/concerrox/emixx/gui/ListEntry.kt
@@ -1,0 +1,100 @@
+package concerrox.emixx.gui
+
+import com.mojang.blaze3d.systems.RenderSystem
+import concerrox.emixx.content.ScreenManager.ENTRY_SIZE
+import concerrox.emixx.gui.components.Switch
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.components.AbstractContainerWidget
+import net.minecraft.client.gui.components.AbstractWidget
+import net.minecraft.client.gui.components.events.ContainerEventHandler
+import net.minecraft.client.gui.narration.NarrationElementOutput
+import net.minecraft.client.gui.screens.Screen
+import net.minecraft.network.chat.Component
+import net.minecraft.resources.ResourceLocation
+
+abstract class ListEntry(private val container: ContainerEventHandler) :
+    AbstractContainerWidget(
+        0, 0, WIDTH, HEIGHT, Component.empty()
+    ) {
+
+    companion object {
+        private val BACKGROUND =
+            ResourceLocation.withDefaultNamespace("textures/gui/inworld_menu_list_background.png")
+        private const val PADDING = 8
+        private const val BORDER_WIDTH = 1
+        const val WIDTH = ENTRY_SIZE * 8 + PADDING * 2 + BORDER_WIDTH * 2
+        const val HEIGHT = ENTRY_SIZE * 2 + PADDING * 2 + BORDER_WIDTH * 2
+    }
+
+    protected abstract val switch: Switch
+    protected abstract val children: MutableList<AbstractWidget>
+
+    abstract fun shouldRenderSwitch(): Boolean
+
+    abstract fun getEntryTitle(): Component?
+
+    abstract fun renderEntry(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, startX: Int, startY: Int, partialTick: Float)
+
+    override fun renderWidget(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
+        val startX = x + BORDER_WIDTH + PADDING
+        val startY = y + BORDER_WIDTH + PADDING
+        renderBackground(guiGraphics)
+        renderBorders(guiGraphics)
+        getEntryTitle()?.let {
+            val maxWidth = WIDTH - BORDER_WIDTH - PADDING - 46
+            val font = Minecraft.getInstance().font
+            if (font.width(it) < maxWidth) {
+                guiGraphics.drawString(
+                    font,
+                    it,
+                    startX,
+                    startY + 2,
+                    0xFFFFFF
+                )
+            } else {
+                renderScrollingString(
+                    guiGraphics,
+                    font,
+                    it,
+                    startX,
+                    startY - 8,
+                    startX + maxWidth,
+                    startY + 12,
+                    0xFFFFFF
+                )
+            }
+        }
+        renderEntry(guiGraphics, mouseX, mouseY, startX, startY, partialTick)
+        if (shouldRenderSwitch()) {
+            switch.setPosition(x + WIDTH - switch.width - BORDER_WIDTH - PADDING, startY)
+            switch.render(guiGraphics, mouseX, mouseY, partialTick)
+        }
+    }
+
+    override fun setFocused(isFocused: Boolean) {
+        if (!isFocused) children.forEach {
+            it.isFocused = false
+        }
+    }
+
+    private fun renderBorders(guiGraphics: GuiGraphics) {
+        RenderSystem.enableBlend()
+        val resourceLocation = Screen.INWORLD_HEADER_SEPARATOR
+        val resourceLocation2 = Screen.INWORLD_FOOTER_SEPARATOR
+        guiGraphics.blit(resourceLocation, x, y, 0f, 0f, getWidth(), 2, 32, 2)
+        guiGraphics.blit(resourceLocation2, x, bottom, 0f, 0f, getWidth(), 2, 32, 2)
+        RenderSystem.disableBlend()
+    }
+
+    private fun renderBackground(guiGraphics: GuiGraphics) {
+        RenderSystem.enableBlend()
+        guiGraphics.blit(BACKGROUND, x, y, right.toFloat(), bottom.toFloat(), getWidth(), getHeight(), 32, 32)
+        RenderSystem.disableBlend()
+    }
+
+    override fun isFocused() = container.focused === this
+    override fun updateWidgetNarration(narrationElementOutput: NarrationElementOutput) {}
+    override fun children() = children
+
+}

--- a/common/src/main/kotlin/concerrox/emixx/gui/ListEntry.kt
+++ b/common/src/main/kotlin/concerrox/emixx/gui/ListEntry.kt
@@ -58,9 +58,9 @@ abstract class ListEntry(private val container: ContainerEventHandler) :
                     font,
                     it,
                     startX,
-                    startY - 8,
+                    startY,
                     startX + maxWidth,
-                    startY + 12,
+                    startY + 2 + font.lineHeight,
                     0xFFFFFF
                 )
             }

--- a/common/src/main/kotlin/concerrox/emixx/gui/components/ImageButton.kt
+++ b/common/src/main/kotlin/concerrox/emixx/gui/components/ImageButton.kt
@@ -5,6 +5,7 @@ import concerrox.emixx.res
 import dev.emi.emi.EmiPort
 import dev.emi.emi.EmiRenderHelper
 import dev.emi.emi.runtime.EmiDrawContext
+import dev.emi.emi.screen.EmiScreenManager
 import dev.emi.emi.screen.widget.SizedButtonWidget
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiGraphics
@@ -67,7 +68,16 @@ class ImageButton : SizedButtonWidget {
         texture = TEXTURE
     }
 
+    private var matchScreenManagerVisibility = false
+
+    fun matchScreenManagerVisibility(): ImageButton {
+        matchScreenManagerVisibility = true
+        return this
+    }
+
     override fun renderWidget(raw: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+        if (matchScreenManagerVisibility && EmiScreenManager.isDisabled()) return
+
         val context = EmiDrawContext.wrap(raw)
         RenderSystem.enableBlend()
         RenderSystem.enableDepthTest()

--- a/common/src/main/resources/assets/emixx/lang/en_us.json
+++ b/common/src/main/resources/assets/emixx/lang/en_us.json
@@ -5,15 +5,19 @@
   "gui.emixx.possible_enchantments_for_enchanted_book": "All the non-treasure enchantments",
   "gui.emixx.random_color": "Random Color",
 
+  "gui.emixx.creative_mode_tab_config": "Creative Mode Tab Config",
   "gui.emixx.stack_group_config": "Stack Group Config",
 
   "emixx.configuration.title": "EMI++ Config",
   "emixx.configuration.creativeModeTabs": "Creative Mode Tabs",
   "emixx.configuration.enableCreativeModeTabs": "Enable Creative Mode Tabs",
   "emixx.configuration.syncSelectedCreativeModeTab": "Sync Selected Creative Mode Tab",
+  "emixx.configuration.disabledCreativeModeTabs": "Disabled Creative Mode Tabs",
+  "emixx.emixx.configuration.disabledCreativeModeTabs.manage": "Configure...",
   "emixx.configuration.stackGroups": "Stack Groups",
-  "emixx.configuration.enableStackGroups": "---------------------",
+  "emixx.configuration.enableStackGroups": "Enable Stack Groups",
   "emixx.configuration.disabledStackGroups": "Disabled Stack Groups",
+  "emixx.emixx.configuration.disabledStackGroups.manage": "Configure...",
 
   "emi.category.emixx.villager_trades": "Villager Trades"
 }


### PR DESCRIPTION
Prevents tabs with no contents from showing, and adds a config to toggle certain tabs.

The tab config has a screen to go with it, same as the stack group config. The stack group config screen code has been refactored to allow it to work for both configs.

Also fixes #8

Prevents selected tab getting reset to index after first initialize, to avoid resetting it whenever you open a recipe mainly