### PR TITLE
Support for KubeJS's groupEntries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Thumbs.db
 *.log
 /.claude/
 /.mcp.json
+/.kotlin/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.modPublish)
+    kotlin("kapt") version "2.2.20"
 }
 
 val modId: String by project
@@ -118,9 +119,11 @@ dependencies {
     // Mixin annotation processor (Mixin 0.8.7 shipped by NeoForge)
     compileOnly("org.spongepowered:mixin:0.8.7:processor")
     annotationProcessor("org.spongepowered:mixin:0.8.7:processor")
+    kapt("org.spongepowered:mixin:0.8.7:processor")
 
     // Support for KubeJS groupEntry
     compileOnly("dev.latvian.mods:kubejs-neoforge:$kubejsVersion")
+    testImplementation(kotlin("test"))
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ val minecraftVersion: String by project
 val neoVersionRange: String by project
 val neoforgeVersion: String by project
 val authorName: String by project
+val kubejsVersion: String by project
 
 version = modVersion
 group = "concerrox.minecraft.emiplusplus"
@@ -91,6 +92,20 @@ repositories {
         name = "TerraformersMC"
         url = uri("https://maven.terraformersmc.com/releases")
     }
+    maven {
+        url = uri("https://maven.latvian.dev/releases")
+        content {
+            includeGroup("dev.latvian.mods")
+            includeGroup("dev.latvian.apps")
+        }
+    }
+
+    maven {
+        url = uri("https://jitpack.io")
+        content {
+            includeGroup("com.github.rtyley")
+        }
+    }
 }
 
 dependencies {
@@ -103,6 +118,9 @@ dependencies {
     // Mixin annotation processor (Mixin 0.8.7 shipped by NeoForge)
     compileOnly("org.spongepowered:mixin:0.8.7:processor")
     annotationProcessor("org.spongepowered:mixin:0.8.7:processor")
+
+    // Support for KubeJS groupEntry
+    compileOnly("dev.latvian.mods:kubejs-neoforge:$kubejsVersion")
 }
 
 tasks {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ modVersion=2.1.0
 minecraftVersion=1.21.1
 neoVersionRange=[21.1,)
 neoforgeVersion=21.1.248
+kubejsVersion=2101.7.2-build.368
 authorName=ConcerroX
 
 org.gradle.jvmargs=-Xmx4G -XX:+UseZGC -XX:+ZGenerational

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ modName=EMI++
 modVersion=2.1.0
 minecraftVersion=1.21.1
 neoVersionRange=[21.1,)
-neoforgeVersion=21.1.90
+neoforgeVersion=21.1.248
 authorName=ConcerroX
 
 org.gradle.jvmargs=-Xmx4G -XX:+UseZGC -XX:+ZGenerational

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 modId=emixx
 modName=EMI++
-modVersion=2.1.0
+modVersion=2.1.1
 minecraftVersion=1.21.1
 neoVersionRange=[21.1,)
 neoforgeVersion=21.1.248

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/concerrox/minecraft/emiplusplus/EmiPlusPlus.kt
+++ b/src/main/kotlin/concerrox/minecraft/emiplusplus/EmiPlusPlus.kt
@@ -1,7 +1,9 @@
 package concerrox.minecraft.emiplusplus
 
 import com.mojang.logging.LogUtils
+import concerrox.minecraft.emiplusplus.group.KubeJSGroupBridge
 import net.neoforged.fml.common.Mod
+import net.neoforged.fml.loading.LoadingModList
 import org.slf4j.Logger
 
 @Mod(EmiPlusPlus.MOD_ID)
@@ -13,5 +15,8 @@ class EmiPlusPlus {
 
     init {
         LOGGER.info("EMI++ initialized!")
+        if (LoadingModList.get().getModFileById("kubejs") != null) {
+            KubeJSGroupBridge.register()
+        }
     }
 }

--- a/src/main/kotlin/concerrox/minecraft/emiplusplus/group/GroupSelector.kt
+++ b/src/main/kotlin/concerrox/minecraft/emiplusplus/group/GroupSelector.kt
@@ -6,10 +6,13 @@ import dev.emi.emi.api.stack.EmiIngredient
 import dev.emi.emi.api.stack.EmiStack
 import dev.emi.emi.api.stack.serializer.EmiIngredientSerializer
 import net.minecraft.core.registries.Registries
-import net.minecraft.resources.ResourceLocation
 import net.minecraft.tags.TagKey
 import net.minecraft.world.item.BlockItem
+import net.minecraft.world.item.crafting.Ingredient
 import net.minecraft.world.level.block.Block
+import net.minecraft.world.level.material.Fluid
+import net.neoforged.neoforge.fluids.FluidStack
+import net.neoforged.neoforge.fluids.crafting.FluidIngredient
 
 /**
  * Selector that determines whether an [EmiStack] belongs to a group.
@@ -21,6 +24,10 @@ import net.minecraft.world.level.block.Block
  *
  * EMI registers `item` and `fluid` by default. Block tags are resolved directly from
  * Minecraft's block registry because EmiTags does not maintain that data.
+ *
+ * [KubeJSItemSelector] and [KubeJSFluidSelector] are not parsed from string notation —
+ * they're constructed directly from KubeJS's `RecipeViewerEvents.groupEntries` data
+ * (see [concerrox.minecraft.emiplusplus.group.KubeJSGroupBridge]).
  */
 sealed class GroupSelector {
 
@@ -55,6 +62,26 @@ sealed class GroupSelector {
         override fun toString(): String = rawNotation
     }
 
+    /** Match items via a raw KubeJS-provided [Ingredient] predicate (from `event.group(...)` on `'item'`). */
+    class KubeJSItemSelector(val ingredient: Ingredient) : GroupSelector() {
+        override fun match(stack: EmiStack): Boolean {
+            val itemStack = stack.itemStack
+            return !itemStack.isEmpty && ingredient.test(itemStack)
+        }
+
+        override fun toString(): String = "kubejs-item-ingredient"
+    }
+
+    /** Match fluids via a raw KubeJS-provided [FluidIngredient] predicate (from `event.group(...)` on `'fluid'`). */
+    class KubeJSFluidSelector(val ingredient: FluidIngredient) : GroupSelector() {
+        override fun match(stack: EmiStack): Boolean {
+            val fluid = stack.key as? Fluid ?: return false
+            return ingredient.test(FluidStack(fluid, 1000))
+        }
+
+        override fun toString(): String = "kubejs-fluid-ingredient"
+    }
+
     abstract fun match(stack: EmiStack): Boolean
 
     companion object {
@@ -68,6 +95,8 @@ sealed class GroupSelector {
             return try {
                 when {
                     notation.startsWith("#block:") -> parseBlockTag(notation)?.let { BlockTagSelector(it, notation) }
+                    notation.startsWith("/") && notation.endsWith("/") && notation.length > 1 ->
+                        RegexSelector(Regex(notation.substring(1, notation.length - 1)), notation)
                     notation.startsWith("#") -> TagSelector(notation)
                     else -> parseId(notation)
                 }
@@ -91,5 +120,11 @@ sealed class GroupSelector {
             val id = Identifier.fromNamespaceAndPath(parts[0], parts[1])
             return TagKey.create(Registries.BLOCK, id)
         }
+    }
+
+    /** Match stacks whose id (namespace:path) matches a regex, like KubeJS's /pattern/ notation. */
+    class RegexSelector(val regex: Regex, val rawNotation: String) : GroupSelector() {
+        override fun match(stack: EmiStack): Boolean = regex.containsMatchIn(stack.id.toString())
+        override fun toString(): String = rawNotation
     }
 }

--- a/src/main/kotlin/concerrox/minecraft/emiplusplus/group/KubeJSGroupBridge.kt
+++ b/src/main/kotlin/concerrox/minecraft/emiplusplus/group/KubeJSGroupBridge.kt
@@ -1,0 +1,34 @@
+package concerrox.minecraft.emiplusplus.group
+
+import dev.latvian.mods.kubejs.recipe.viewer.server.FluidData
+import dev.latvian.mods.kubejs.recipe.viewer.server.ItemData
+import dev.latvian.mods.kubejs.recipe.viewer.server.RecipeViewerData
+import dev.latvian.mods.kubejs.recipe.viewer.server.RemoteRecipeViewerDataUpdatedEvent
+import net.neoforged.neoforge.common.NeoForge
+
+/**
+ * Bridges KubeJS's `RecipeViewerEvents.groupEntries` data into EMI++'s group system.
+ * KubeJS syncs grouped-entry data to the client and fires [RemoteRecipeViewerDataUpdatedEvent]
+ * on the NeoForge event bus whenever it changes; we cache the latest payload here and
+ * re-bake EMI++'s groups when it updates.
+ *
+ * Only call [register] if the `kubejs` mod is actually loaded — see [concerrox.minecraft.emiplusplus.EmiPlusPlus].
+ */
+object KubeJSGroupBridge {
+
+    @Volatile
+    private var remote: RecipeViewerData? = null
+
+    fun register() {
+        NeoForge.EVENT_BUS.addListener(::onRemoteData)
+    }
+
+    private fun onRemoteData(event: RemoteRecipeViewerDataUpdatedEvent) {
+        remote = event.data
+        StackGroups.bakeOnly()
+    }
+
+    fun itemGroups(): List<ItemData.Group> = remote?.itemData()?.groupedEntries().orEmpty()
+
+    fun fluidGroups(): List<FluidData.Group> = remote?.fluidData()?.groupedEntries().orEmpty()
+}

--- a/src/main/kotlin/concerrox/minecraft/emiplusplus/group/StackGroups.kt
+++ b/src/main/kotlin/concerrox/minecraft/emiplusplus/group/StackGroups.kt
@@ -93,6 +93,7 @@ object StackGroups {
     private fun bake() {
         GroupStateManager.load()
 
+        val allGroups = groups + kubeJSGroupConfigs()
         val selectors = mutableMapOf<String, List<GroupSelector>>()
         for (group in groups) {
             val parsed = GroupConfig.parseSelectors(group)
@@ -100,19 +101,48 @@ object StackGroups {
                 selectors[group.id] = parsed
             }
         }
+        for ((_, id) in allGroups) {
+            if (id in selectors) continue
+            val parsed = kubeJSSelectorsFor(id)
+            if (parsed.isNotEmpty()) {
+                selectors[id] = parsed
+            }
+        }
 
         baseStacks = if (CreativeTabController.isEnabled()) CreativeTabController.currentBaseStacks() else EmiStackList.stacks
-        assembler = GroupAssembler(baseStacks, groups, selectors)
+        assembler = GroupAssembler(baseStacks, allGroups, selectors)
         indexStacks = assembler!!.buildIndexStacks()
         restoreExpandStates()
         needsSync = true
 
         LOGGER.info(
             "Baked {} groups with {} selectors, {} total stacks",
-            groups.size,
+            allGroups.size,
             selectors.values.sumOf { it.size },
             indexStacks.size
         )
+    }
+
+    /** Synthesizes [GroupConfig]s for groups defined via KubeJS's `RecipeViewerEvents.groupEntries`. */
+    private fun kubeJSGroupConfigs(): List<GroupConfig> {
+        val itemGroups = KubeJSGroupBridge.itemGroups().map {
+            GroupConfig(name = it.description().string, id = it.groupId().toString())
+        }
+        val fluidGroups = KubeJSGroupBridge.fluidGroups().map {
+            GroupConfig(name = it.description().string, id = it.groupId().toString())
+        }
+        return itemGroups + fluidGroups
+    }
+
+    /** Resolves the [GroupSelector] for a KubeJS-sourced group id (item or fluid, whichever matches). */
+    private fun kubeJSSelectorsFor(groupId: String): List<GroupSelector> {
+        KubeJSGroupBridge.itemGroups().find { it.groupId().toString() == groupId }?.let {
+            return listOf(GroupSelector.KubeJSItemSelector(it.filter()))
+        }
+        KubeJSGroupBridge.fluidGroups().find { it.groupId().toString() == groupId }?.let {
+            return listOf(GroupSelector.KubeJSFluidSelector(it.filter()))
+        }
+        return emptyList()
     }
 
     private fun restoreExpandStates() {

--- a/update.json
+++ b/update.json
@@ -2,10 +2,11 @@
   "homepage": "https://github.com/ConcerroX/emi-plus-plus",
   "1.21.1": {
     "2.0.0": "Rewrite by Claude Code\nPer-group border color, show/hide border and fill options\nIn-game group editor via EMI settings → Edit Groups",
-    "2.1.0": "Creative Mode Tabs for EMI index\nBlock tag support in stack groups\nEditor UX fixes: modal dialogs, duplicate ID validation, auto paging, tag source labels"
+    "2.1.0": "Creative Mode Tabs for EMI index\nBlock tag support in stack groups\nEditor UX fixes: modal dialogs, duplicate ID validation, auto paging, tag source labels",
+    "2.1.1": "Support for KubeJS's RecipeViewerEvents#groupEntries"
   },
   "promos": {
-    "1.21.1-latest": "2.1.0",
-    "1.21.1-recommended": "2.1.0"
+    "1.21.1-latest": "2.1.1",
+    "1.21.1-recommended": "2.1.1"
   }
 }


### PR DESCRIPTION
Resolves https://github.com/ConcerroX/emi-plus-plus/issues/10

Allows https://kubejs.com/wiki/events/RecipeViewerEvents/groupEntries to be done via Kube now with support of `item` and `fluid`